### PR TITLE
fix: remote copy sys temporary

### DIFF
--- a/.gnfiles/build/feature/ten_package.gni
+++ b/.gnfiles/build/feature/ten_package.gni
@@ -298,8 +298,6 @@ template("ten_package") {
                       "extension_group",
                       "--pkg-type",
                       "protocol",
-                      "--pkg-type",
-                      "system",
                     ],
                     "list lines")
 


### PR DESCRIPTION
It requires all system packages have `ten_package` target for the copying, which is not true for some system packages such as `ten_runtime_go`, `agora_rtc_sdk`, `azure_speech_sdk`, `nlohmann_json`, etc. Update all of them seem tricky. On the other hand, currently only cpp app requires it, but mostly we're using go or python main. So try to disable it by default. It's able to enable it on branch for cpp apps before we figure out better solution. 